### PR TITLE
bump version to 4.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+out
 dist-ssr
 *.local
 

--- a/README.md
+++ b/README.md
@@ -39,24 +39,44 @@ Configure>/search/howsearchworks
 * This works because google.com and google.com.au share the same route structure. A traditional bookmark will also store the FQDN, which isn't useful when you have many websites that share the same route structure
 
 ## Change Log
+CHANGES IN VERSION 4.3.0
+
+Extension Options menu
+
+Change Requests:
+
+* Option to sync config paths to your browser account.
+  * FireFox sync depends on what is configured in FireFox settings. Default sync should be 5 minutes
+
+Bug Fixes:
+* Go button overflowing to new line on FireFox
+
 CHANGES IN VERSION 4.2.0
+
 Added support for FireFox
 
 CHANGES IN VERSION 4.1.0
+
 Added Context menu for quick navigation
 
 CHANGES IN VERSION 4.0.0
+
 Migrated code to React/Typescript
 
 CHANGES IN VERSION 3.0:
+
 Bug fixes
+
 Updated for Chrome extension compliance
 
 CHANGES IN VERSION 2.2:
+
 RegEx transformations: You can now add a RegEx transformation in this format:
 `{Label}>{RegEx URL match}<<<{Link to generate (with option attributes in this format: $n)}`
+
 For example:
 `Edit this page>(\/pages\/?id=)([0-9]{1,9}).*<<</editpage/?id=$2`
+
 If HappierPath finds a RegEx match on the current URL, it will create a link using the transformation path.
 
 ## To do (in no particular order):

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "happier-path",
   "private": true,
-  "version": "4.2.3",
+  "version": "4.3.0",
   "type": "module",
   "scripts": {
     "build-dev-chrome": "tsc -b && cross-env BROWSER=chrome vite build --mode development",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -11,7 +11,7 @@ export function getManifest({ mode, browser }: ManifestOptions) {
   return {
     manifest_version: 3,
     name: 'HappierPath',
-    version: '4.2.3',
+    version: '4.3.0',
     description: '... because everything is still relative.',
     action: {
       default_icon: 'icon_16.png',


### PR DESCRIPTION
CHANGES IN VERSION 4.3.0

Extension Options menu

Change Requests:

* Option to sync config paths to your browser account.
  * FireFox sync depends on what is configured in FireFox settings. Default sync should be 5 minutes

Bug Fixes:
* Go button overflowing to new line on FireFox
