### PR TITLE
Remove the body from the release in the release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,6 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: "HappierPath Release ${{ github.ref_name }}"
-          body: |
-            📢 New release of HappierPath!
-
-            - 🧩 Chrome extension
-            - 🦊 Firefox extension
           draft: false
           prerelease: false
           files: |


### PR DESCRIPTION
Removed the body from the release. I prefer the generated body from the github ui.

Example:
![image](https://github.com/user-attachments/assets/a0c8dc5f-3297-4693-a645-41dc4975be4c)
